### PR TITLE
Update CI and clean up code with golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,21 @@
+name: GolangCI Lint
+on: [pull_request]
+
+env:
+  GO111MODULE: on
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    name: Lint
+    steps:
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.15.0'
+      - name: Get golangci-lint
+        run: go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Run Lint
+        run: golangci-lint run -v --out-format github-actions

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,59 @@
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - dogsled
+    - dupl
+    - errcheck
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - goerr113
+    - gofmt
+    - golint
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - maligned
+    - misspell
+    - nakedret
+    - nestif
+    - nlreturn
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - scopelint
+    - staticcheck
+    - structcheck
+    - testpackage
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - wsl
+
+issues:
+  include:
+    - EXC0002
+
+linters-settings:
+  maligned:
+    suggest-new: true
+  nolintlint:
+    allow-unused: false
+    allow-leading-space: false
+    require-explanation: true
+    require-specific: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,14 @@ language: go
 
 os:
   - linux
+  - osx
 arch:
   - amd64
   - arm64
 go:
+  - 1.15.x
   - 1.14.x
   - 1.13.x
-  - 1.12.x
-  - 1.11.x
-  - master
 
 env:
   global:
@@ -20,22 +19,17 @@ env:
 
 dist: bionic
 go_import_path: kreklow.us/go/cli
-script: go test -v ./...
+script: go test -v -race ./...
 
 jobs:
-  allow_failures:
-    - go: master
-    - arch: arm64
-  fast_finish: true
   include:
-    - name: "Race detector / Codecov"
+    - name: "Test Coverage"
       stage: validate
       script: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
       after_success: bash <(curl -s https://codecov.io/bash)
     - name: "Refresh GoDoc and Go Report Card"
       stage: refresh
-      if: |
-        branch = master AND type = push
+      if: branch = master AND type = push
       language: shell
       install: skip
       script:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Overview
-[![GoDoc](https://godoc.org/kreklow.us/go/cli?status.svg)](https://godoc.org/kreklow.us/go/cli)
+[![PkgGoDev](https://pkg.go.dev/badge/kreklow.us/go/cli)](https://pkg.go.dev/kreklow.us/go/cli)
 ![GitHub](https://img.shields.io/github/license/cjkreklow/cli.svg)
 ![GitHub tag (latest SemVer)](https://img.shields.io/github/tag/cjkreklow/cli.svg)
 [![Build Status](https://www.travis-ci.org/cjkreklow/cli.svg?branch=master)](https://www.travis-ci.org/cjkreklow/cli)

--- a/cmd.go
+++ b/cmd.go
@@ -39,18 +39,18 @@ import (
 // properly initialized Cmd.
 type Cmd struct {
 	flagSet      *flag.FlagSet
+	outWriter    io.Writer
+	outLock      sync.Mutex
+	errWriter    io.Writer
+	errLock      sync.Mutex
+	outLiveBuf   bytes.Buffer
+	outLiveLines int
+	exitTimeout  atomic.Value
 	exitWg       *sync.WaitGroup
 	exitChan     chan bool
 	exitOnce     sync.Once
-	exitTimeout  atomic.Value
-	errWriter    io.Writer
-	outWriter    io.Writer
-	errLock      sync.Mutex
-	outLock      sync.Mutex
 	errIsTerm    bool
 	outIsTerm    bool
-	outLiveLines int
-	outLiveBuf   bytes.Buffer
 	err          error
 }
 
@@ -66,6 +66,7 @@ func NewCmd() *Cmd {
 
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+
 	go c.watchExitSignal(sigChan)
 
 	c.flagSet = flag.NewFlagSet(os.Args[0], flag.ExitOnError)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+coverage:
+  precision: 2
+  round: down
+  range: "80...95"
+  status:
+    project:
+      default:
+        target: 95%
+    patch:
+      default:
+        target: auto
+        threshold: 5%

--- a/exit.go
+++ b/exit.go
@@ -75,6 +75,7 @@ func (c *Cmd) Done() {
 // avoid exiting prematurely.
 func (c *Cmd) Wait() error {
 	c.exitWg.Wait()
+
 	return c.err
 }
 

--- a/write.go
+++ b/write.go
@@ -38,6 +38,7 @@ func (c *Cmd) SetOutputWriter(w io.Writer) {
 	defer c.outLock.Unlock()
 	c.outWriter = w
 	c.outIsTerm = false
+
 	if f, ok := w.(*os.File); ok {
 		c.outIsTerm = isatty.IsTerminal(f.Fd())
 	}
@@ -49,9 +50,11 @@ func (c *Cmd) SetOutputWriter(w io.Writer) {
 func (c *Cmd) Print(v ...interface{}) (int, error) {
 	c.outLock.Lock()
 	defer c.outLock.Unlock()
+
 	if c.outIsTerm {
 		c.outLiveLines = 0
 	}
+
 	return fmt.Fprint(c.outWriter, v...)
 }
 
@@ -61,13 +64,15 @@ func (c *Cmd) Print(v ...interface{}) (int, error) {
 func (c *Cmd) Printf(f string, v ...interface{}) (int, error) {
 	c.outLock.Lock()
 	defer c.outLock.Unlock()
+
 	if c.outIsTerm {
 		c.outLiveLines = 0
 	}
+
 	return fmt.Fprintf(c.outWriter, f, v...)
 }
 
-// LPrintf implements a "live update" version of cmd.Printf. If the
+// Lprintf implements a "live update" version of cmd.Printf. If the
 // io.Writer specified by SetOutputWriter appears to be a terminal, the
 // previously output line(s) will be cleared before the new line(s) are
 // written. It is safe for concurrent use, although concurrent updates
@@ -75,14 +80,17 @@ func (c *Cmd) Printf(f string, v ...interface{}) (int, error) {
 func (c *Cmd) Lprintf(f string, v ...interface{}) (int, error) {
 	c.outLock.Lock()
 	defer c.outLock.Unlock()
+
 	if !c.outIsTerm {
 		return fmt.Fprintf(c.outWriter, f, v...)
 	}
+
 	c.clearLiveLines()
 	c.outLiveBuf.Reset()
 	fmt.Fprintf(&c.outLiveBuf, f, v...)
 	b := c.outLiveBuf.Bytes()
 	c.outLiveLines = bytes.Count(b, []byte{'\n'})
+
 	return c.outWriter.Write(b)
 }
 
@@ -92,9 +100,11 @@ func (c *Cmd) Lprintf(f string, v ...interface{}) (int, error) {
 func (c *Cmd) Println(v ...interface{}) (int, error) {
 	c.outLock.Lock()
 	defer c.outLock.Unlock()
+
 	if c.outIsTerm {
 		c.outLiveLines = 0
 	}
+
 	return fmt.Fprintln(c.outWriter, v...)
 }
 
@@ -103,45 +113,53 @@ func (c *Cmd) Println(v ...interface{}) (int, error) {
 func (c *Cmd) SetErrorWriter(w io.Writer) {
 	c.errLock.Lock()
 	defer c.errLock.Unlock()
+
 	c.errWriter = w
 	c.errIsTerm = false
+
 	if f, ok := w.(*os.File); ok {
 		c.errIsTerm = isatty.IsTerminal(f.Fd())
 	}
 }
 
-// EPrint is a wrapper around fmt.Print with the destination set to the
+// Eprint is a wrapper around fmt.Print with the destination set to the
 // io.Writer specified by SetErrorWriter. It is safe for concurrent use.
 func (c *Cmd) Eprint(v ...interface{}) (int, error) {
 	c.errLock.Lock()
 	defer c.errLock.Unlock()
+
 	if c.errIsTerm {
 		c.outLiveLines = 0
 	}
+
 	return fmt.Fprint(c.errWriter, v...)
 }
 
-// EPrintf is a wrapper around fmt.Printf with the destination set to
+// Eprintf is a wrapper around fmt.Printf with the destination set to
 // the io.Writer specified by SetErrorWriter. It is safe for concurrent
 // use.
 func (c *Cmd) Eprintf(f string, v ...interface{}) (int, error) {
 	c.errLock.Lock()
 	defer c.errLock.Unlock()
+
 	if c.errIsTerm {
 		c.outLiveLines = 0
 	}
+
 	return fmt.Fprintf(c.errWriter, f, v...)
 }
 
-// EPrintln is a wrapper around fmt.Println with the destination set to
+// Eprintln is a wrapper around fmt.Println with the destination set to
 // the io.Writer specified by SetErrorWriter. It is safe for concurrent
 // use.
 func (c *Cmd) Eprintln(v ...interface{}) (int, error) {
 	c.errLock.Lock()
 	defer c.errLock.Unlock()
+
 	if c.errIsTerm {
 		c.outLiveLines = 0
 	}
+
 	return fmt.Fprintln(c.errWriter, v...)
 }
 
@@ -152,5 +170,6 @@ func (c *Cmd) clearLiveLines() {
 			panic(err)
 		}
 	}
+
 	c.outLiveLines = 0
 }

--- a/write_test.go
+++ b/write_test.go
@@ -65,6 +65,19 @@ func testLprintfBuffer(t *testing.T) {
 	}
 }
 
+func writeLprintf(cmd *cli.Cmd) {
+	cmd.Print("print 1\n")
+	cmd.Eprintf("print %d\n", 2)
+	cmd.Println("print 3")
+	cmd.Lprintf("print %d\n", 4)
+	cmd.Lprintf("print %d\n", 5)
+	cmd.Eprint("print 6\n")
+	cmd.Lprintf("print %d\n", 7)
+	cmd.Printf("print %d\n", 8)
+	cmd.Eprintln("print 9")
+	cmd.Print("END")
+}
+
 func testLprintfConsole(t *testing.T) {
 	cons, err := expect.NewConsole()
 	if err != nil {
@@ -75,8 +88,10 @@ func testLprintfConsole(t *testing.T) {
 
 	wg := new(sync.WaitGroup)
 	wg.Add(1)
+
 	go func() {
 		defer wg.Done()
+
 		outstr, err = cons.ExpectString("END")
 		if err != nil {
 			t.Error("unexpected error", err)
@@ -87,17 +102,8 @@ func testLprintfConsole(t *testing.T) {
 	cmd.SetOutputWriter(cons.Tty())
 	cmd.SetErrorWriter(cons.Tty())
 
-	cmd.Print("print 1\n")
-	cmd.Eprintf("print %d\n", 2)
-	cmd.Println("print 3")
-	cmd.Lprintf("print %d\n", 4)
-	cmd.Lprintf("print %d\n", 5)
-	cmd.Eprint("print 6\n")
-	cmd.Lprintf("print %d\n", 7)
-	cmd.Printf("print %d\n", 8)
-	cmd.Eprintln("print 9")
+	writeLprintf(cmd)
 
-	cmd.Print("END")
 	wg.Wait()
 
 	if outstr != "print 1\r\nprint 2\r\nprint 3\r\nprint 4\r\n\x1b[1A\x1b[2Kprint 5\r\nprint 6\r\nprint 7\r\nprint 8\r\nprint 9\r\nEND" {
@@ -116,6 +122,7 @@ func testLprintfConsole(t *testing.T) {
 
 	defer func() {
 		p := recover()
+
 		err, ok := p.(error)
 		if !ok ||
 			!strings.HasPrefix(err.Error(), "write") ||
@@ -123,6 +130,7 @@ func testLprintfConsole(t *testing.T) {
 			t.Error("unexpected panic:", p)
 		}
 	}()
+
 	_, err = cmd.Lprintf("TEST\n")
 	t.Error("expected panic, got", err)
 }


### PR DESCRIPTION
Added GitHub action for running golangci-lint on pull requests, and cleaned up code to eliminate existing linting errors.

Also added OSX as a build target for Travis and bumped the Travis Go versions to 1.13-1.15.