### PR TITLE
Print err on forced exit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: GolangCI Lint
+name: Lint
 on: [pull_request]
 
 env:
@@ -7,7 +7,7 @@ env:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: Lint
+    name: GolangCI-Lint
     steps:
       - name: Setup Go
         uses: actions/setup-go@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,53 +1,67 @@
 linters:
   disable-all: true
   enable:
-    - asciicheck
-    - bodyclose
-    - deadcode
-    - dogsled
-    - dupl
-    - errcheck
-    - funlen
-    - gochecknoglobals
-    - gochecknoinits
-    - gocognit
-    - goconst
-    - gocritic
-    - gocyclo
-    - godot
-    - godox
-    - goerr113
-    - gofmt
-    - golint
-    - goprintffuncname
-    - gosec
-    - gosimple
-    - govet
-    - ineffassign
-    - interfacer
-    - maligned
-    - misspell
-    - nakedret
-    - nestif
-    - nlreturn
-    - nolintlint
-    - prealloc
-    - rowserrcheck
-    - scopelint
-    - staticcheck
-    - structcheck
-    - testpackage
-    - typecheck
-    - unconvert
-    - unparam
-    - unused
-    - varcheck
-    - whitespace
-    - wsl
+    - asciicheck       # Check for non-ASCII identifiers
+    - bodyclose        # Checks whether HTTP response body is closed successfully
+    - deadcode         # Finds unused code
+    - dogsled          # Checks assignments with too many blank identifiers
+    - dupl             # Code clone detection
+    - errcheck         # Checking for unchecked errors
+    - exhaustive       # Check exhaustiveness of enum switch statements
+    - exportloopref    # Checks for pointers to enclosing loop variables
+    - funlen           # Detection of long functions
+    - gochecknoglobals # Checks that no globals are present
+    - gochecknoinits   # Checks that no init functions are present in Go code
+    - gocognit         # Computes and checks the cognitive complexity of functions
+    - goconst          # Finds repeated strings that could be replaced by a constant
+    - gocritic         # The most opinionated Go source code linter
+    - gocyclo          # Computes and checks the cyclomatic complexity of functions
+    - godot            # Check if comments end in a period
+    - godox            # Detection of FIXME, TODO and other comment keywords
+    - goerr113         # Check error handling expressions
+    - gofmt            # Checks whether code was gofmt-ed
+    - golint           # Prints out style mistakes
+    - goprintffuncname # Checks that printf-like functions are named with `f` at the end
+    - gosec            # Inspects source code for security problems
+    - gosimple         # Specializes in simplifying code
+    - govet            # Reports suspicious constructs, such as Printf calls whose arguments do not align with the format string
+    - ineffassign      # Detects when assignments to existing variables are not used
+    - interfacer       # Suggests narrower interface types
+    - maligned         # Detect Go structs that would take less memory if their fields were sorted
+    - misspell         # Finds commonly misspelled English words in comments
+    - nakedret         # Finds naked returns in functions greater than a specified function length
+    - nestif           # Reports deeply nested if statements
+    - nlreturn         # Checks for a new line before return and branch statements
+    - nolintlint       # Reports ill-formed or insufficient nolint directives
+    - prealloc         # Finds slice declarations that could potentially be preallocated
+    - rowserrcheck     # Checks whether err of rows is checked successfully
+    - scopelint        # Checks for unpinned variables in go programs
+    - staticcheck      # Go vet on steroids, applying a ton of static analysis checks
+    - structcheck      # Finds unused struct fields
+    - testpackage      # Makes you use a separate _test package
+    - typecheck        # Like the front-end of a Go compiler, parses and type-checks Go code
+    - unconvert        # Remove unnecessary type conversions
+    - unparam          # Reports unused function parameters
+    - unused           # Checks for unused constants, variables, functions and types
+    - varcheck         # Finds unused global variables and constants
+    - whitespace       # Detection of leading and trailing whitespace
+    - wsl              # Whitespace Linter - Forces you to use empty lines!
+    #- depguard         # Checks if package imports are in a list of acceptable packages
+    #- gci              # Control package import order and make it always deterministic
+    #- gofumpt          # Checks whether code was gofumpt-ed
+    #- goheader         # Checks if file header matches to pattern
+    #- goimports        # Does everything that gofmt does and checks unused imports
+    #- gomnd            # An analyzer to detect magic numbers
+    #- gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    #- lll              # Reports long lines
+    #- noctx            # Finds sending HTTP request without context.Context
+    #- sqlclosecheck    # Checks that sql.Rows and sql.Stmt are closed.
+    #- stylecheck       # Replacement for golint
 
 issues:
   include:
     - EXC0002
+    - EXC0005
 
 linters-settings:
   maligned:

--- a/cmd.go
+++ b/cmd.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Collin Kreklow
+// Copyright 2020 Collin Kreklow
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -33,7 +33,7 @@ import (
 	"kreklow.us/go/cli"
 )
 
-//nolint:goerr113
+//nolint:goerr113 // keep example simple
 func Example() {
 	cmd := cli.NewCmd()
 	msgs := make(chan []byte, 1)

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Collin Kreklow
+// Copyright 2020 Collin Kreklow
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,12 +1,12 @@
 coverage:
   precision: 2
   round: down
-  range: "80...95"
+  range: "75...90"
   status:
     project:
       default:
-        target: 95%
+        target: 90%
     patch:
       default:
         target: auto
-        threshold: 5%
+        threshold: 10%

--- a/exit.go
+++ b/exit.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Collin Kreklow
+// Copyright 2020 Collin Kreklow
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.13
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20200312175327-da48e75238e2
-	github.com/creack/pty v1.1.9 // indirect
+	github.com/creack/pty v1.1.11 // indirect
 	github.com/kr/pty v1.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/stretchr/testify v1.3.0 // indirect
-	golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 // indirect
+	golang.org/x/sys v0.0.0-20200929083018-4d22bbb62b3c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/Netflix/go-expect v0.0.0-20200312175327-da48e75238e2 h1:y2avNRjCeJT8b
 github.com/Netflix/go-expect v0.0.0-20200312175327-da48e75238e2/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
 github.com/creack/pty v1.1.7 h1:6pwm8kMQKCmgUg0ZHTm5+/YvRK0s3THD/28+T6/kk4A=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
-github.com/creack/pty v1.1.9 h1:uDmaGzcdjhF4i/plgjmEsriH11Y0o7RKapEf/LDaM3w=
-github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
+github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/kr/pty v1.1.8 h1:AkaSdXYQOWeaO3neb8EM634ahkXXe3jYbVh/F9lq+GI=
@@ -16,5 +16,5 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3 h1:5B6i6EAiSYyejWfvc5Rc9BbI3rzIsrrXfAQBWnYfn+w=
-golang.org/x/sys v0.0.0-20200501145240-bc7a7d42d5c3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200929083018-4d22bbb62b3c h1:/h0vtH0PyU0xAoZJVcRw1k0Ng+U0JAy3QDiFmppIlIE=
+golang.org/x/sys v0.0.0-20200929083018-4d22bbb62b3c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/write.go
+++ b/write.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Collin Kreklow
+// Copyright 2020 Collin Kreklow
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/write_test.go
+++ b/write_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Collin Kreklow
+// Copyright 2020 Collin Kreklow
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the


### PR DESCRIPTION
If an error is waiting on the cmd but we end up forcing the exit due to timeout or a repeated signal, the error is lost. Change that to print the error on those paths.